### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -12,18 +12,18 @@ LCDSPI	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
-init                KEYWORD2
-write               KEYWORD2
-print               KEYWORD2
-clear               KEYWORD2
-home                KEYWORD2
-setCursor           KEYWORD2
-cursor              KEYWORD2
-noCursor            KEYWORD2
-blink               KEYWORD2
-noBlink             KEYWORD2
-display             KEYWORD2
-noDisplay           KEYWORD2
+init	KEYWORD2
+write	KEYWORD2
+print	KEYWORD2
+clear	KEYWORD2
+home	KEYWORD2
+setCursor	KEYWORD2
+cursor	KEYWORD2
+noCursor	KEYWORD2
+blink	KEYWORD2
+noBlink	KEYWORD2
+display	KEYWORD2
+noDisplay	KEYWORD2
 
 ######################################
 # Instances (KEYWORD2)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords